### PR TITLE
Fixed a problem with insert_bulk

### DIFF
--- a/Zebra_Database.php
+++ b/Zebra_Database.php
@@ -1748,7 +1748,8 @@ class Zebra_Database
     {
 
         // if $data is not an array of arrays
-        if (!is_array(array_pop(array_values($data))))
+        $tmp = array_values($data);
+        if (!is_array(array_pop($tmp))) 
 
             // save debug information
             $this->_log('errors', array(


### PR DESCRIPTION
php 5.4.16
Correct use of insert_bulk ($a = array(array("",""), array("",""));) causes this error:
'Problem "Strict standards: Only variables should be passed by reference"'
The solution is based on comments on stackoverflow (http://stackoverflow.com/q/2354609)

(The changes in line 4145 are done by github.com - sry)
