### PR TITLE
Fix backlashes injected by mysqli escape

### DIFF
--- a/Zebra_Database.php
+++ b/Zebra_Database.php
@@ -2215,7 +2215,7 @@ class Zebra_Database
                         // otherwise, mysqli_real_escape_string the items in replacements
                         // also, replace anything that looks like $45 to \$45 or else the next preg_replace-s will treat
                         // it as references
-                        else $replacements2[$key] = '\'' . preg_replace('/\$([0-9]*)/', '\\\$$1', $this->escape($replacement)) . '\'';
+                        else $replacements2[$key] = '\'' . preg_replace(array('/\\\\/','/\$([0-9]*)/'), array('\\\\\\\\','\\\$$1'), $this->escape($replacement)) . '\'';
 
                         // and also, prepare the new pattern to be replaced afterwards
                         $pattern2[$key] = '/' . $randomstr . '/';


### PR DESCRIPTION
I was trying to insert some binary data with null chars and ran into a weird problem, tracked it down to preg_replace requiring backslashes to be doubled if used inside of replacements.

``` php
$original = "string\x00with\x00nulls\x00andDollar\\$23";
$replacements = $db->escape($original);
$randomstr = '/MD5VALUE/';
echo "Original PRE-REPLACED value: $original" . PHP_EOL;
echo "Escaped PRE-REPLACED value: $replacements" . PHP_EOL;
$sql = "MD5VALUE";
$replacements = '\'' . preg_replace('/\$([0-9]*)/', '\\\$$1',$replacements) . '\'';
$sql = preg_replace($randomstr, $replacements, $sql,1);
echo 'Currently inserted: ' . $sql .  PHP_EOL;

$sql = "MD5VALUE";
$replacements = '\'' . preg_replace(array('/\\\\/','/\$([0-9]*)/'), array('\\\\\\\\','\\\$$1'), $db->escape($original)) . '\'';
$sql = preg_replace($randomstr, $replacements, $sql, 1);
echo 'Fixed: ' . $sql .  PHP_EOL;
```

Output:

```
Original PRE-REPLACED value: stringwithnullsandDollar\$23
Escaped PRE-REPLACED value: string\0with\0nulls\0andDollar\\$23
Currently inserted: 'stringMD5VALUEwithMD5VALUEnullsMD5VALUEandDollar\$23'
Fixed: 'string\0with\0nulls\0andDollar\\$23'
```

Line 3111 also uses `preg_replace('/\$([0-9]*)/', '\\\$$1',$match[0])` but doesn't escape it with `mysqli_real_escape_string()` so I figured that didn't need to be changed. My problem was with the null char but I'm pretty sure this would have effected other things with backslashes, like \n or \r.
