### PR TITLE
realpath for auto resource_path

### DIFF
--- a/Zebra_Database.php
+++ b/Zebra_Database.php
@@ -3546,7 +3546,7 @@ class Zebra_Database
 
                 // this is the url that will be used for automatically including
                 // the CSS and the JavaScript files
-                $path = rtrim(preg_replace('/\\\/', '/', '//' . $_SERVER['SERVER_NAME'] . ($_SERVER['SERVER_PORT'] != '80' ? ':' . $_SERVER['SERVER_PORT'] : '') . DIRECTORY_SEPARATOR . substr(dirname(__FILE__), strlen($_SERVER['DOCUMENT_ROOT']))), '/');
+                $path = rtrim(preg_replace('/\\\/', '/', '//' . $_SERVER['SERVER_NAME'] . ($_SERVER['SERVER_PORT'] != '80' ? ':' . $_SERVER['SERVER_PORT'] : '') . DIRECTORY_SEPARATOR . substr(dirname(__FILE__), strlen(realpath($_SERVER['DOCUMENT_ROOT'])))), '/');
 
             // link the required javascript
             $output = '<script type="text/javascript" src="' . $path . '/public/javascript/database.src.js"></script>' . $output;


### PR DESCRIPTION
Recently switched to a symlinked doc root and noticed an interesting problem, `dirname(__FILE__)` resolves to the real resolved path (not the symlink) and `$_SERVER['DOCUMENT_ROOT']` resolves to the unresolved symlink path. So if your paths don't have the same amount of characters it causes a problem.

The `DIRECTORY_SEPARATOR` doesn't seem to be needed, at least on my dev server it adds an extra / between domain and path but it doesn't do anything bad so I figured I'd leave it in case its needed elsewhere.
