### PR TITLE
Suppress memcache warning if memcache extension is not available

### DIFF
--- a/Zebra_Database.php
+++ b/Zebra_Database.php
@@ -652,7 +652,7 @@ class Zebra_Database
     {
 
         // if the "memcache" extension is loaded and the caching method is set to "memcache"
-        if (extension_loaded('memcache') && $this->caching_method == 'memcache')
+        if (!extension_loaded('memcache') || $this->caching_method == 'memcache')
 
             // suppress the warning telling the developer to use memcache for caching query results
             unset($this->warnings['memcache']);


### PR DESCRIPTION
memcache warning is issued even if memcache extension is not available.
This will enable the message only if
the extension is available but it is not the selected caching method.

This invites another question, however: do we want a warning if
caching_method == 'memcache' but the extension is not available?
(I wouldn't bother if there's some sensible fallback.)